### PR TITLE
Add filter to add other possible template paths to look for templates.

### DIFF
--- a/core/class_core.php
+++ b/core/class_core.php
@@ -981,7 +981,7 @@ class WPP_Core {
       $template_found = WPP_F::get_template_part( array(
         "property-{$type}",
         "property",
-      ), array( WPP_Templates ) );
+      ), apply_filters( 'wpp_possible_template_paths', array( WPP_Templates ) ) );
 
       //** Load the first found template */
       if ( $template_found ) {
@@ -1027,7 +1027,7 @@ class WPP_Core {
         $template_found = WPP_F::get_template_part( array(
           "property-search-result",
           "property-overview-page",
-        ), array( WPP_Templates ) );
+        ), apply_filters( 'wpp_possible_template_paths', array( WPP_Templates ) ) );
 
         //** Load the first found template */
         if ( $template_found ) {
@@ -1480,7 +1480,7 @@ class WPP_Core {
       "property-overview-{$property_type}",
       "property-{$template}",
       "property-overview",
-    ), array( WPP_Templates ) );
+    ), apply_filters( 'wpp_possible_template_paths', array( WPP_Templates ) ) );
 
     if ( $template_found ) {
       include $template_found;
@@ -1683,7 +1683,7 @@ class WPP_Core {
     $hide_infobox = ( $args[ 'hide_infobox' ] == 'true' ? true : false );
 
     //** Find most appropriate template */
-    $template_found = WPP_F::get_template_part( array( "content-single-property-map", "property-map" ), array( WPP_Templates ) );
+    $template_found = WPP_F::get_template_part( array( "content-single-property-map", "property-map" ), apply_filters( 'wpp_possible_template_paths', array( WPP_Templates ) ) );
     if ( !$template_found ) {
       return false;
     }

--- a/templates/wpi_checkout-feps.php
+++ b/templates/wpi_checkout-feps.php
@@ -49,7 +49,7 @@
         "{$gateway_key}-checkout-{$template}.tpl",
         "{$gateway_key}-checkout",
         "{$gateway_key}-checkout.tpl",
-      ), array( WPP_Templates , WPI_Gateways_Path . '/templates' ) );
+      ), apply_filters( 'wpp_possible_template_paths', array( WPP_Templates , WPI_Gateways_Path . '/templates' ) ) );
 
       if( $template_found ) {
         include $template_found;


### PR DESCRIPTION
Currently there is no way to define a template path in a theme and theme developers have to add wp-property specific templates to the theme's root directory.

Adding a subdirectory in a theme keeps wp-property's files more organized.

This filter allows a theme to define another template path to look for templates.

Here is how I using this filter in a theme I am developing:

``` php
function filter_wp_property_possible_template_paths( $paths ) {
    array_unshift( $paths, get_template_directory() . '/wp-property' );

    return $paths;
}
add_action( 'wpp_possible_template_paths', 'filter_wp_property_possible_template_paths' );
```
