### PR TITLE
Add filter to make it easier for developers to remove the default styles.

### DIFF
--- a/core/class_core.php
+++ b/core/class_core.php
@@ -858,8 +858,12 @@ class WPP_Core {
     //** Load global wp-property script on all frontend pages */
     wp_enqueue_script( 'wp-property-global' );
 
-    //** Load essential styles that are used in widgets */
-    wp_enqueue_style( 'wp-property-frontend' );
+    //** Possibly load essential styles that are used in widgets */
+    if ( apply_filters( 'ud::custom_styles', false ) === false ) {
+        wp_enqueue_style( 'wp-property-frontend' );
+    }
+
+    //** Possibly load theme specific styles */
     wp_enqueue_style( 'wp-property-theme-specific' );
 
     //** Load non-essential scripts and styles if option is enabled to load them globally */

--- a/core/ui/page_settings.php
+++ b/core/ui/page_settings.php
@@ -202,10 +202,16 @@ if ( get_option( 'permalink_structure' ) == '' ) {
     </tr>
 
     <tr>
-      <th><?php _e( 'Styles and Scripts', 'wpp' ); ?></th>
+      <?php if ( apply_filters( 'ud::custom_styles', false ) === false ) : ?>
+        <th><?php _e( 'Styles and Scripts', 'wpp' ); ?></th>
+      <?php else : ?>
+        <th><?php _e( 'Scripts', 'wpp' ); ?></th>
+      <?php endif; ?>
       <td>
         <ul>
-          <li><?php echo $using_custom_css ? WPP_F::checkbox( "name=wpp_settings[configuration][autoload_css]&label=" . __( 'Load default CSS. If unchecked, the wp-properties.css in your theme folder will not be loaded.', 'wpp' ), $wp_properties[ 'configuration' ][ 'autoload_css' ] ) : WPP_F::checkbox( "name=wpp_settings[configuration][autoload_css]&label=" . __( 'Load default CSS.', 'wpp' ), $wp_properties[ 'configuration' ][ 'autoload_css' ] ); ?></li>
+          <?php if ( apply_filters( 'ud::custom_styles', false ) === false ) : ?>
+            <li><?php echo $using_custom_css ? WPP_F::checkbox( "name=wpp_settings[configuration][autoload_css]&label=" . __( 'Load default CSS. If unchecked, the wp-properties.css in your theme folder will not be loaded.', 'wpp' ), $wp_properties[ 'configuration' ][ 'autoload_css' ] ) : WPP_F::checkbox( "name=wpp_settings[configuration][autoload_css]&label=" . __( 'Load default CSS.', 'wpp' ), $wp_properties[ 'configuration' ][ 'autoload_css' ] ); ?></li>
+          <?php endif; ?>
 
           <?php if ( WPP_F::has_theme_specific_stylesheet() ) { ?>
             <li>


### PR DESCRIPTION
Although a developer can remove the styles completely by simply dequeueing the stylesheet, the option on the settings page remains and can be confusing for users if no stylesheet is ever loaded.

This filter will make it easier for developers to remove the default styles from WP Property completely (including the option on the settings page).
