### PR TITLE
Make WPP_Core::shortcode_property_overview static.

### DIFF
--- a/core/class_core.php
+++ b/core/class_core.php
@@ -1326,7 +1326,7 @@ class WPP_Core {
    * @uses WPP_F::get_properties()
    *
    */
-  function shortcode_property_overview( $atts = "" ) {
+  public static function shortcode_property_overview( $atts = "" ) {
     global $wp_properties, $wpp_query, $property, $post, $wp_query;
 
     $atts = wp_parse_args( $atts, array() );


### PR DESCRIPTION
One notice I keep seeing:

```
Strict Standards: Non-static method WPP_Core::shortcode_property_overview() should not be called statically in .....
```

Changing this method to static solves this problem.
