### PR TITLE
Avoid double sharp for strict search fields value

### DIFF
--- a/core/class_core.php
+++ b/core/class_core.php
@@ -1531,6 +1531,9 @@ class WPP_Core {
               continue;
             }
           }
+          /* To avoid double # check if ajax_call then try to strip already existing # */
+          if ( $wpp_query[ 'ajax_call' ] )
+            $val = trim ($val , '#' );
           $wpp_query[ 'query' ][ $key ] = '#' . $val . '#';
         }
       }


### PR DESCRIPTION
Check if is AJAX request to avoid double # in strict search fields value that cause empty result set; then strips them from $val with trim().
