### PR TITLE
v2.1.8

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,8 @@
+### 2.1.8 ( May 23, 2016 )
+* Added default Search Input and Data Entry types for Property Attributes on first WP-Property install.
+* Fixed default list of Property Types on first WP-Property install.
+* Fixed issue with duplicated Currency symbol on Single Property page.
+
 ### 2.1.7 ( May 18, 2016 )
 * Added Date picker for Property Search form.
 * Added ability to remove all default attributes, meta attributes and property types from Developer tab on Settings page.

--- a/lib/classes/class-settings.php
+++ b/lib/classes/class-settings.php
@@ -7,9 +7,10 @@
  */
 namespace UsabilityDynamics\WPP {
 
-  if( !class_exists( 'UsabilityDynamics\WPP\Settings' ) ) {
+  if (!class_exists('UsabilityDynamics\WPP\Settings')) {
 
-    class Settings extends \UsabilityDynamics\Settings {
+    class Settings extends \UsabilityDynamics\Settings
+    {
 
       /**
        * Constructor
@@ -19,17 +20,17 @@ namespace UsabilityDynamics\WPP {
        * @todo For the love of god, only apply the defaults on installation. - potanin@UD
        * @param bool $args
        */
-      public function __construct( $args = false ) {
+      public function __construct($args = false) {
         global $wp_properties;
-        
+
         //** STEP 1. Default */
-        
-        parent::__construct( $args );
-        
+
+        parent::__construct($args);
+
         //** STEP 2. */
-        
+
         $data = array();
-         
+
         //** This slug will be used to display properties on the front-end.  Most likely overwriten by get_option('wpp_settings'); */
         $data['configuration'] = array(
           'autoload_css' => 'true',
@@ -59,7 +60,7 @@ namespace UsabilityDynamics\WPP {
         $data['configuration']['admin_ui'] = array(
           'overview_table_thumbnail_size' => 'tiny_thumb'
         );
-        
+
         $data['default_coords']['latitude'] = '57.7973333';
         $data['default_coords']['longitude'] = '12.0502107';
 
@@ -81,166 +82,196 @@ namespace UsabilityDynamics\WPP {
 
         //** Image URLs. */
         $data['images']['map_icon_shadow'] = WPP_URL . "images/map_icon_shadow.png";
-        
+
         $data['configuration']['google_maps']['infobox_settings'] = array(
           'show_direction_link' => true,
           'show_property_title' => true
         );
 
         //** Default attribute label descriptions for the back-end */
-        $data[ 'descriptions' ] = array(
+        $data['descriptions'] = array(
           'descriptions' => array(
-            'property_type' => sprintf( __('The %s type will determine the layout.',ud_get_wp_property()->domain), \WPP_F::property_label() ),
-            'custom_attribute_overview' => __('Customize what appears in search results in the attribute section.  For example: 1bed, 2baths, area varies slightly.',ud_get_wp_property()->domain),
-            'tagline' => __('Will appear on overview pages and on top of every listing page.',ud_get_wp_property()->domain)
+            'property_type' => sprintf(__('The %s type will determine the layout.', ud_get_wp_property()->domain), \WPP_F::property_label()),
+            'custom_attribute_overview' => __('Customize what appears in search results in the attribute section.  For example: 1bed, 2baths, area varies slightly.', ud_get_wp_property()->domain),
+            'tagline' => __('Will appear on overview pages and on top of every listing page.', ud_get_wp_property()->domain)
           )
         );
 
         $_stored_settings = $this->get();
 
         //** Merge with default data. */
-        $this->set( \UsabilityDynamics\Utility::extend( $data, $this->get() ) );
+        $this->set(\UsabilityDynamics\Utility::extend($data, $this->get()));
 
         // Check if settings have or have been upated. (we determine if configuration is good)
         // @todo Add a better _version_ check.
-        if( isset( $_stored_settings[ '_updated' ] ) && isset( $_stored_settings[ 'version' ] ) && $_stored_settings[ 'version' ] === '2.0.0' ) {
+        if (isset($_stored_settings['_updated']) && isset($_stored_settings['version']) && $_stored_settings['version'] === '2.0.0') {
           return $wp_properties = $this->get();
         }
 
         // Continue on to load/enforce defaults.
 
         //** STEP 3. */
-        
+
         //** Setup default property types to be used. */
-	      $b_install = get_option('wpp_settings');
-        $d = $this->get( 'property_types', false );
-        
-        // Should only be set on install, not added on every request. These literally can not be removed from settings... -potanin@UD
-        // It is adding these defaults only if types are empty (install) - korotkov@UD
-        if( empty( $d ) || !is_array( $d ) ) {
+        $b_install = get_option('wpp_settings');
+
+        $d = $this->get('property_types', false);
+        if (empty($d) || !is_array($d)) {
           $ar = array();
-            if( empty($b_install) ) {
-              $ar = array(
-                'building' => __( 'Building', ud_get_wp_property()->domain ),
-                'floorplan' => __( 'Floorplan', ud_get_wp_property()->domain ),
-                'single_family_home' => __( 'Single Family Home', ud_get_wp_property()->domain )
-              );
-            }
-          $this->set( 'property_stats', $ar );
-      }
+          if (empty($b_install)) {
+            $ar = array(
+              'building' => __('Building', ud_get_wp_property()->domain),
+              'floorplan' => __('Floorplan', ud_get_wp_property()->domain),
+              'single_family_home' => __('Single Family Home', ud_get_wp_property()->domain)
+            );
+          }
+          $this->set('property_types', $ar);
+        }
 
         //** Setup property types to be used. */
-        $d = !$this->get( 'property_inheritance', false );
-       if( !$d || !is_array( $d ) ) {
-         $this->set( 'property_inheritance', array(
-           'floorplan' => array( 'street_number', 'route', 'state', 'postal_code', 'location', 'display_address', 'address_is_formatted' )
-         ) );
-       }
-          
-        //** Property stats. Can be searchable, displayed as input boxes on editing page. */
-        $d = $this->get( 'property_stats', false );
-        if( empty( $d ) || !is_array( $d ) ) {
-         $ar = array();
-          if( empty($b_install) ) {
-            $ar = array(
-             'location' => __('Address',ud_get_wp_property()->domain),
-             'price' => __('Price',ud_get_wp_property()->domain),
-             'deposit' => __('Deposit',ud_get_wp_property()->domain),
-             'area' => __('Area',ud_get_wp_property()->domain),
-             'phone_number' => __('Phone Number',ud_get_wp_property()->domain),
-            );
-          }
-         $this->set( 'property_stats', $ar );
+        $d = !$this->get('property_inheritance', false);
+        if (!$d || !is_array($d)) {
+          $this->set('property_inheritance', array(
+            'floorplan' => array('street_number', 'route', 'state', 'postal_code', 'location', 'display_address', 'address_is_formatted')
+          ));
         }
-        //** Property meta.  Typically not searchable, displayed as textarea on editing page. */
-        $d = $this->get( 'property_meta', false );
-        if( empty( $d ) || !is_array( $d ) ) {
-         $ar = array();
-          if( empty($b_install) ) {
-            $ar = array(
-             'lease_terms' => __('Lease Terms',ud_get_wp_property()->domain),
-             'pet_policy' => __('Pet Policy',ud_get_wp_property()->domain),
-             'school' => __('School',ud_get_wp_property()->domain),
-             'tagline' => __('Tagline',ud_get_wp_property()->domain)
-            );
-          }
-         $this->set( 'property_meta', $ar );
-        }
-        //** On property editing page - determines which fields to hide for a particular property type */
-        $d = $this->get( 'hidden_attributes', false );
 
-        if( !is_array( $d ) ) {
-          $this->set( 'hidden_attributes', array(
+        //** Property stats. Can be searchable, displayed as input boxes on editing page. */
+        $d = $this->get('property_stats', false);
+        if (empty($d) || !is_array($d)) {
+          $ar = array();
+          $ar2 = array();
+          if (empty($b_install)) {
+            $ar = array(
+              'location' => __('Address', ud_get_wp_property()->domain),
+              'price' => __('Price', ud_get_wp_property()->domain),
+              'deposit' => __('Deposit', ud_get_wp_property()->domain),
+              'area' => __('Area', ud_get_wp_property()->domain),
+              'phone_number' => __('Phone Number', ud_get_wp_property()->domain),
+            );
+            $ar2 = array(
+              'location' => '',
+              'price' => '',
+              'deposit' => '',
+              'area' => '',
+              'phone_number' => '',
+            );
+          }
+          $this->set('property_stats', $ar);
+          $this->set('predefined_values', $ar2);
+        }
+
+        //** Property meta.  Typically not searchable, displayed as textarea on editing page. */
+        $d = $this->get('property_meta', false);
+        if (empty($d) || !is_array($d)) {
+          $ar = array();
+          if (empty($b_install)) {
+            $ar = array(
+              'lease_terms' => __('Lease Terms', ud_get_wp_property()->domain),
+              'pet_policy' => __('Pet Policy', ud_get_wp_property()->domain),
+              'school' => __('School', ud_get_wp_property()->domain),
+              'tagline' => __('Tagline', ud_get_wp_property()->domain)
+            );
+          }
+          $this->set('property_meta', $ar);
+        }
+
+        //** On property editing page - determines which fields to hide for a particular property type */
+        $d = $this->get('hidden_attributes', false);
+        if (!is_array($d)) {
+          $this->set('hidden_attributes', array(
             'floorplan' => array('location', 'parking', 'school'), /*  Floorplans inherit location. Parking and school are generally same for all floorplans in a building */
             'building' => array('price', 'bedrooms', 'bathrooms', 'area', 'deposit'),
             'single_family_home' => array('deposit', 'lease_terms', 'pet_policy')
-          ) );
+          ));
         }
 
         //** Determines property types that have addresses. */
-        $d = $this->get( 'location_matters', false );
-        if( !is_array( $d ) ) {
-          $this->set( 'location_matters', array(
+        $d = $this->get('location_matters', false);
+        if (!is_array($d)) {
+          $this->set('location_matters', array(
             'building',
-            'single_family_home' 
-          ) );
+            'single_family_home'
+          ));
         }
 
         //** Determine which property types should actually be searchable. */
-        $d = $this->get( 'searchable_property_types', false );
-        if( !is_array( $d ) ) {
-          $this->set( 'searchable_property_types', array(
+        $d = $this->get('searchable_property_types', false);
+        if (!is_array($d)) {
+          $this->set('searchable_property_types', array(
             'floorplan',
             'single_family_home'
-          ) );
+          ));
         }
-        
+
         //** Attributes to use in searching. */
-        $d = $this->get( 'searchable_attributes', false );
-        if( !is_array( $d ) ) {
-          $this->set( 'searchable_attributes', array(
+        $d = $this->get('searchable_attributes', false);
+        if (!is_array($d)) {
+          $this->set('searchable_attributes', array(
             'area',
             'deposit',
             'bedrooms',
             'bathrooms',
             'city',
             'price'
-          ) );
+          ));
+        }
+
+        //** Attributes to use in searching. */
+        $d = $this->get('searchable_attr_fields', false);
+        if (!is_array($d)) {
+          $this->set('searchable_attr_fields', array(
+            'price' => 'range_input',
+            'deposit' => 'range_input',
+            'area' => 'range_input',
+          ));
+        }
+
+        //** Attributes Classifications */
+        $d = $this->get('admin_attr_fields', false);
+        if (!is_array($d)) {
+          $this->set('admin_attr_fields', array(
+            'location' => 'input',
+            'price' => 'currency',
+            'deposit' => 'currency',
+            'area' => 'number',
+            'phone_number' => 'input',
+          ));
         }
 
         //** Convert phrases to searchable values.  Converts string stats into numeric values for searching and filtering. */
-        $d = $this->get( 'search_conversions', false );
-        if( !is_array( $d ) ) {
-          $this->set( 'search_conversions', array(
-            'bedrooms' => array( __( 'Studio', ud_get_wp_property()->domain ) => '0.5' )
-          ) );
+        $d = $this->get('search_conversions', false);
+        if (!is_array($d)) {
+          $this->set('search_conversions', array(
+            'bedrooms' => array(__('Studio', ud_get_wp_property()->domain) => '0.5')
+          ));
         }
 
         //** Don't load defaults if settings exist in db */
-        $d = $this->get( 'image_sizes', false );
-        if( !is_array( $d ) ) {
-          $this->set( 'image_sizes', array(
-            'map_thumb' => array('width'=> '75', 'height' => '75'),
-            'tiny_thumb' => array('width'=> '100', 'height' => '100'),
-            'sidebar_wide' => array('width'=> '195', 'height' => '130'),
-            'slideshow' => array('width'=> '640', 'height' => '235')
-          ) );
+        $d = $this->get('image_sizes', false);
+        if (!is_array($d)) {
+          $this->set('image_sizes', array(
+            'map_thumb' => array('width' => '75', 'height' => '75'),
+            'tiny_thumb' => array('width' => '100', 'height' => '100'),
+            'sidebar_wide' => array('width' => '195', 'height' => '130'),
+            'slideshow' => array('width' => '640', 'height' => '235')
+          ));
         }
 
-        $d = $this->get( 'configuration.google_maps.infobox_attributes', false );
-        if( !is_array( $d ) ) {
-          $this->set( 'configuration.google_maps.infobox_attributes', array(
+        $d = $this->get('configuration.google_maps.infobox_attributes', false);
+        if (!is_array($d)) {
+          $this->set('configuration.google_maps.infobox_attributes', array(
             'bedrooms',
             'bathrooms',
             'price'
-          ) );
+          ));
         }
-        
+
         //** STEP 4. */
 
         $wp_properties = $this->get();
 
-        
+
       }
 
     }

--- a/lib/default_api.php
+++ b/lib/default_api.php
@@ -569,7 +569,7 @@ function add_dollar_sign( $content ) {
   $currency_symbol = ( !empty( $wp_properties[ 'configuration' ][ 'currency_symbol' ] ) ? $wp_properties[ 'configuration' ][ 'currency_symbol' ] : "$" );
   $currency_symbol_placement = ( !empty( $wp_properties[ 'configuration' ][ 'currency_symbol_placement' ] ) ? $wp_properties[ 'configuration' ][ 'currency_symbol_placement' ] : "before" );
 
-  $content = trim( str_replace( array( "$", "," ), "", $content ) );
+  $content = trim( str_replace( array( $currency_symbol, "," ), "", $content ) );
 
   if ( !is_numeric( $content ) ) {
     return preg_replace_callback( '/(\d+)/', create_function(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://usabilitydynamics.com/product/wp-property/
 Tags: property management, real estate, listings, properties, property, wp-property, real estate cms, wordpress real estate, listings, estate, MLS, IDX, RETS, XML Import
 Requires at least: 4.0
 Tested up to: 4.5.2
-Stable tag: 2.1.7
+Stable tag: 2.1.8
 
 == Description ==
 
@@ -225,6 +225,11 @@ If you submit a popular idea on UserVoice, we WILL integrate it sooner or later.
 * Security fixes
 
 == Changelog ==
+
+= 2.1.8 =
+* Added default Search Input and Data Entry types for Property Attributes on first WP-Property install.
+* Fixed default list of Property Types on first WP-Property install.
+* Fixed issue with duplicated Currency symbol on Single Property page.
 
 = 2.1.7 =
 * Added Date picker for Property Search form.

--- a/static/splashes/install.php
+++ b/static/splashes/install.php
@@ -54,10 +54,9 @@ wp_cache_flush();
     <h3><?php printf( __( 'WP-Property %s important changes', ud_get_wp_property()->domain ), ud_get_wp_property( 'version' ) ); ?>:</h3>
 
     <ul>
-      <li>Added ability to sort properties by modified date for Property Overview widget.</li>
-      <li>Added option to export properties to CSV file on Help Tab of Settings page.</li>
-      <li>Fixed replacing of plugin's settings data with default values on updating WP-Property settings in some cases.</li>
-      <li>Fixed showing of Multi-Checkbox values.</li>
+      <li>Added default Search Input and Data Entry types for Property Attributes on first WP-Property install.</li>
+      <li>Fixed default list of Property Types on first WP-Property install.</li>
+      <li>Fixed issue with duplicated Currency symbol on Single Property page.</li>
     </ul>
 
   </div>

--- a/static/splashes/upgrade.php
+++ b/static/splashes/upgrade.php
@@ -54,10 +54,9 @@ wp_cache_flush();
     <h3><?php printf( __( 'WP-Property %s important changes', ud_get_wp_property()->domain ), ud_get_wp_property( 'version' ) ); ?>:</h3>
 
     <ul>
-      <li>Added ability to sort properties by modified date for Property Overview widget.</li>
-      <li>Added option to export properties to CSV file on Help Tab of Settings page.</li>
-      <li>Fixed replacing of plugin's settings data with default values on updating WP-Property settings in some cases.</li>
-      <li>Fixed showing of Multi-Checkbox values.</li>
+      <li>Added default Search Input and Data Entry types for Property Attributes on first WP-Property install.</li>
+      <li>Fixed default list of Property Types on first WP-Property install.</li>
+      <li>Fixed issue with duplicated Currency symbol on Single Property page.</li>
     </ul>
 
   </div>

--- a/wp-property.php
+++ b/wp-property.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.usabilitydynamics.com/product/wp-property/
  * Description: Property and Real Estate Management Plugin for WordPress.  Create a directory of real estate / rental properties and integrate them into you WordPress CMS.
  * Author: Usability Dynamics, Inc.
- * Version: 2.1.7
+ * Version: 2.1.8
  * Requires at least: 4.0
  * Tested up to: 4.5.2
  * Text Domain: wpp


### PR DESCRIPTION
- Added default Search Input and Data Entry types for Property Attributes on first WP-Property install.
- Fixed default list of Property Types on first WP-Property install.
- Fixed issue with duplicated Currency symbol on Single Property page.
