### PR TITLE
wp-property/wp-property-power-tools#9

### DIFF
--- a/lib/class_core.php
+++ b/lib/class_core.php
@@ -25,6 +25,8 @@ class WPP_Core {
       ini_set( 'memory_limit', '128M' );
     }
 
+    //** Modifing post query according to capability */    
+    add_filter('pre_get_posts', array( $this, 'capability_wpp_property' ));
     //** Modify request to change feed */
     add_filter( 'request', 'property_feed' );
 
@@ -451,6 +453,27 @@ class WPP_Core {
     return $attributes;
   }
 
+  /**
+   * Limiting to view only own property if 
+   * user don't have edit_others_posts capability.
+   * 
+   * @since 2.2.0.1
+   * @author alim
+   */
+
+  public function capability_wpp_property($query) {
+    global $current_screen;
+
+    if( 'property' != $query->query['post_type'] || !$query->is_admin )
+        return $query;
+
+    if( !current_user_can( 'edit_others_posts' ) ) {
+      global $user_ID;
+      $query->set('author', $user_ID );
+    }
+    return $query;
+  }
+  
   /**
    * May be return thumbnail ID for property.
    * HOOK on get_post_meta

--- a/lib/class_functions.php
+++ b/lib/class_functions.php
@@ -5085,13 +5085,20 @@ class WPP_F extends UsabilityDynamics\Utility
   static public function get_properties_quantity($post_status = array('publish'))
   {
     global $wpdb;
+    $where = '';
+    
+    /** Limiting to view only own property if user don't have edit_others_posts capability. */
+    if(!current_user_can( 'edit_others_posts' )){
+      global $user_ID;
+      $where .= " AND post_author = $user_ID";
+    }
 
     $results = $wpdb->get_col("
       SELECT ID
       FROM {$wpdb->posts}
       WHERE post_status IN ('" . implode("','", $post_status) . "')
         AND post_type = 'property'
-    ");
+    " . $where );
 
     $results = apply_filters('wpp_get_properties_quantity', $results, $post_status);
 

--- a/lib/classes/class-admin-overview.php
+++ b/lib/classes/class-admin-overview.php
@@ -191,7 +191,13 @@ namespace UsabilityDynamics\WPP {
         );
 
         $defined = array();
-        foreach($fields as $field) {
+        foreach($fields as $key => $field) {
+          /** Removing author field if current user don't have edit_others_posts capability. */
+          if($field['id'] == 'author' && !current_user_can( 'edit_others_posts' )){
+            unset($fields[$key]);
+            continue;
+          }
+
           array_push( $defined, $field['id'] );
         }
 


### PR DESCRIPTION
wp-property/wp-property-power-tools#9
Limiting to view only own property if 
user don't have edit_others_posts capability.