### PR TITLE
Fixed add_dolar_sign function to display decimal values correctly

### DIFF
--- a/lib/default_api.php
+++ b/lib/default_api.php
@@ -570,16 +570,18 @@ function add_display_address( $property ) {
  */
 function add_dollar_sign( $content ) {
   global $wp_properties;
-
   $currency_symbol = ( !empty( $wp_properties[ 'configuration' ][ 'currency_symbol' ] ) ? $wp_properties[ 'configuration' ][ 'currency_symbol' ] : "$" );
+  $decimal_symbol = ( !empty( $wp_properties[ 'configuration' ][ 'dec_point' ] ) ? $wp_properties[ 'configuration' ][ 'dec_point' ] : "." );
   $currency_symbol_placement = ( !empty( $wp_properties[ 'configuration' ][ 'currency_symbol_placement' ] ) ? $wp_properties[ 'configuration' ][ 'currency_symbol_placement' ] : "before" );
 
   if( is_string( $content ) ) {
     $content = trim( str_replace( array( $currency_symbol, "," ), "", $content ) );
   }
-
+   
+  $pattern = sprintf("/(\d{1,}[\%s]?\d{1,})/",$decimal_symbol);
+  
   if ( !is_numeric( $content ) ) {
-    return preg_replace_callback( '/(\d+)/', function( $matches ) {
+    return preg_replace_callback( $pattern, function( $matches ) {
       return add_dollar_sign( $matches[0] );
     }, $content );
   } else {


### PR DESCRIPTION
Hi W-Property Guys
I found a little bug when I was trying to use decimal values on the field price.
![decimal_value_with_dollar_sign_before_decimal_point](https://user-images.githubusercontent.com/31689/81131528-0e93ba80-8f11-11ea-9ba0-15d503d9a97b.jpg)
